### PR TITLE
fix: breadcrumb navigation css

### DIFF
--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -20,12 +20,7 @@ const CourseBreadcrumb = ({
         <li className="col-auto p-0 mx-2 text-primary-500 text-truncate text-nowrap" role="presentation" aria-hidden>/</li>
       )}
 
-      <li style={{
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-      }}
-      >
+      <li className="reactive-crumbs">
         { getConfig().ENABLE_JUMPNAV !== 'true' || content.length < 2 || !isStaff
           ? (
             <Link

--- a/src/index.scss
+++ b/src/index.scss
@@ -356,6 +356,18 @@
   }
 }
 
+.reactive-crumbs {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  &:hover,
+  &:focus,
+  &:focus-within,
+  &:active {
+    overflow: visible;
+  }
+}
+
 .raised-card {
   border: 0 !important;
   box-shadow: 0 .0625rem .125rem rgba(0, 0, 0, .2) !important;


### PR DESCRIPTION
The breadcrumb navigation popup was hidden due to css property `overflow: hidden` in parent `li` element. This is a tricky issue in css where we want the parent to have `overflow:hidden` normally (to hide content overflowing the container) but show popups from its children element.

It was working normally in nutmeg version as the parent element of popup (which has `position: absolute`) did not have `position: relative`, causing the popup to be displayed in the top left of the breadcrumb parent div like so:

![image](https://github.com/open-craft/frontend-app-learning/assets/10894099/1566c18a-57a3-40d4-b7c1-28caf2354267)

This was fixed in palm by this [commit](https://github.com/openedx/paragon/commit/f409171435e81fd252e5136e4ab9c9cae07b1ce3) but it now positioned the popup inside list element which has `overflow:hidden` property.

We are overriding the `overflow` property on focus to retain both behaviour.

![image](https://github.com/open-craft/frontend-app-learning/assets/10894099/29999a96-b7cc-48cb-88a4-11ae657f1662)

**Test instructions:**

* Setup latest tutor (palm) locally
* Checkout this PR/branch.
* Mount frontend-app-learning using `tutor config save --append MOUNTS=/path/to/frontend-app-learning`
* Run `tutor dev launch`
* Visit any course and use the breadcrumb navigation buttons. **Note:** You need to login using staff/admin user as breadcrumbs with navigation feature is only visible to staff users.