### PR TITLE
[BB-8929] fix: remove redundant form-control class for MasqueradeUserNameInput

### DIFF
--- a/src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx
+++ b/src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx
@@ -135,7 +135,7 @@ class MasqueradeWidget extends Component {
             <span className="col-auto col-form-label pl-3" id="masquerade-search-label">{`${specificLearnerInputText}:`}</span>
             <MasqueradeUserNameInput
               id="masquerade-search"
-              className="col-4 form-control"
+              className="col-4"
               autoFocus={autoFocus}
               defaultValue={masqueradeUsername}
               onError={(errorMessage) => this.onError(errorMessage)}


### PR DESCRIPTION
As the FormControl element already comes with the form-control class, the extra class specified on the MasqueradeUserInput is applied to the div container of the <input> causing double input box effect. This is not visible in themes where the container div's padding is zero. But appears when padding is not set.

Internal-ref: https://tasks.opencraft.com/browse/BB-8929

## Note about upstreaming the changes

An upstream PR for this ~is not required~ may not be necessary, as upstream has

1. switched from `edx/paragon` to `openedx/paragon`
2. the `MasqueradeUserNameInput.jsx` now uses the `Input` component instead of the `FormControl` component which doesn't render an extra div around the <input> element.

Yet, I have created a PR with the same changes at: https://github.com/openedx/frontend-app-learning/pull/1416

## UI Changes

### Before
![image](https://github.com/open-craft/frontend-app-learning/assets/383862/4510f54c-a150-4fee-b959-4f03aead72a7)

### After

![image](https://github.com/open-craft/frontend-app-learning/assets/383862/39adc22b-d5b6-4bc1-9306-501fe2c301e8)
