### PR TITLE
fix: remove the extra form-control from MasqueradeWidget

### DIFF
--- a/src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx
+++ b/src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx
@@ -135,7 +135,7 @@ class MasqueradeWidget extends Component {
             <span className="col-auto col-form-label pl-3" id="masquerade-search-label">{`${specificLearnerInputText}:`}</span>
             <MasqueradeUserNameInput
               id="masquerade-search"
-              className="col-4 form-control"
+              className="col-4"
               autoFocus={autoFocus}
               defaultValue={masqueradeUsername}
               onError={(errorMessage) => this.onError(errorMessage)}


### PR DESCRIPTION
The form-control class on the MasqueradeWidget causes an extra box to appear along with the input box of MasqueradeUserNameInput. Removing it in this commit to fix the UI.

Interal-ref: https://tasks.opencraft.com/browse/BB-8929

Does the same thing as https://github.com/open-craft/frontend-app-learning/pull/24