### PR TITLE
feat: Add support for showing and hiding parts of the progress page

### DIFF
--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -25,8 +25,11 @@ const ProgressTab = () => {
 
   const applyLockedOverlay = gradesFeatureIsFullyLocked ? 'locked-overlay' : '';
   const [visibility, setVisibility] = useState({});
-  // To maintain compatibility eith
-  const isVisible = (component) => visibility?.[`show${component}`] ?? true;
+  const [isLoaded, setIsLoaded] = useState(false);
+  // If the visibility is undefined before loading is complete, then hide the component,
+  // however if it's still false after loading is complete that means the visibility just
+  // isn't configured, in which case default to being visible.
+  const isVisible = (component) => visibility?.[`show${component}`] ?? isLoaded;
   useEffect(async () => {
     const authenticatedUser = getAuthenticatedUser();
     const url = new URL(`${getConfig().LMS_BASE_URL}/api/courses/v2/blocks/`);
@@ -35,6 +38,7 @@ const ProgressTab = () => {
     url.searchParams.append('requested_fields', 'other_course_settings');
     const { data } = await getAuthenticatedHttpClient().get(url.href, {});
     setVisibility(data.blocks[data.root]?.other_course_settings?.progressPage ?? {});
+    setIsLoaded(true);
   }, [courseId]);
 
   const windowWidth = useWindowSize().width;

--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -20,7 +20,7 @@ const ProgressTab = () => {
   } = useSelector(state => state.courseHome);
 
   const {
-    gradesFeatureIsFullyLocked,
+    gradesFeatureIsFullyLocked, disableProgressGraph,
   } = useModel('progress', courseId);
 
   const applyLockedOverlay = gradesFeatureIsFullyLocked ? 'locked-overlay' : '';
@@ -56,7 +56,7 @@ const ProgressTab = () => {
       <div className="row w-100 m-0">
         {/* Main body */}
         <div className="col-12 col-md-8 p-0">
-          <CourseCompletion />
+          {!disableProgressGraph && <CourseCompletion />}
           {!wideScreen && isVisible('CertificateStatus') && <CertificateStatus />}
           {isVisible('Grades') && <CourseGrade />}
           {isVisible('GradeBreakdown') && (

--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -59,10 +59,12 @@ const ProgressTab = () => {
           <CourseCompletion />
           {!wideScreen && isVisible('CertificateStatus') && <CertificateStatus />}
           {isVisible('Grades') && <CourseGrade />}
-          <div className={`grades my-4 p-4 rounded raised-card ${applyLockedOverlay}`} aria-hidden={gradesFeatureIsFullyLocked}>
-            {isVisible('GradeSummary') && <GradeSummary />}
-            {isVisible('GradeSummary') && <DetailedGrades />}
-          </div>
+          {isVisible('GradeBreakdown') && (
+            <div className={`grades my-4 p-4 rounded raised-card ${applyLockedOverlay}`} aria-hidden={gradesFeatureIsFullyLocked}>
+              <GradeSummary />
+              <DetailedGrades />
+            </div>
+          )}
         </div>
 
         {/* Side panel */}

--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -59,10 +59,10 @@ const ProgressTab = () => {
           {!disableProgressGraph && <CourseCompletion />}
           {!wideScreen && isVisible('CertificateStatus') && <CertificateStatus />}
           {isVisible('Grades') && <CourseGrade />}
-          {isVisible('GradeBreakdown') && (
+          {(isVisible('GradeSummary') || isVisible('GradeDetails')) && (
             <div className={`grades my-4 p-4 rounded raised-card ${applyLockedOverlay}`} aria-hidden={gradesFeatureIsFullyLocked}>
-              <GradeSummary />
-              <DetailedGrades />
+              {isVisible('GradeSummary') && <GradeSummary />}
+              {isVisible('GradeDetails') && <DetailedGrades />}
             </div>
           )}
         </div>


### PR DESCRIPTION
This PR adds support for hiding or showing components on the progress page based on configuration stored in `other_course_settings`. 

These settings can be toggled with: https://github.com/open-craft/frontend-app-authoring/pull/71

Private-ref: [BB-9200](https://tasks.opencraft.com/browse/BB-9200)