### PR TITLE
feat: Add plugin slots for progress page components

### DIFF
--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -2,14 +2,13 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { breakpoints, useWindowSize } from '@openedx/paragon';
 
-import CertificateStatus from './certificate-status/CertificateStatus';
 import CourseCompletion from './course-completion/CourseCompletion';
-import CourseGrade from './grades/course-grade/CourseGrade';
-import DetailedGrades from './grades/detailed-grades/DetailedGrades';
-import GradeSummary from './grades/grade-summary/GradeSummary';
 import ProgressHeader from './ProgressHeader';
-import RelatedLinks from './related-links/RelatedLinks';
 
+import ProgressTabCertificateStatusSlot from '../../plugin-slots/ProgressTabCertificateStatusSlot';
+import ProgressTabCourseGradeSlot from '../../plugin-slots/ProgressTabCourseGradeSlot';
+import ProgressTabGradeBreakdownSlot from '../../plugin-slots/ProgressTabGradeBreakdownSlot';
+import ProgressTabRelatedLinksSlot from '../../plugin-slots/ProgressTabRelatedLinksSlot';
 import { useModel } from '../../generic/model-store';
 
 const ProgressTab = () => {
@@ -17,11 +16,7 @@ const ProgressTab = () => {
     courseId,
   } = useSelector(state => state.courseHome);
 
-  const {
-    gradesFeatureIsFullyLocked, disableProgressGraph,
-  } = useModel('progress', courseId);
-
-  const applyLockedOverlay = gradesFeatureIsFullyLocked ? 'locked-overlay' : '';
+  const { disableProgressGraph } = useModel('progress', courseId);
 
   const windowWidth = useWindowSize().width;
   if (windowWidth === undefined) {
@@ -39,18 +34,15 @@ const ProgressTab = () => {
         {/* Main body */}
         <div className="col-12 col-md-8 p-0">
           {!disableProgressGraph && <CourseCompletion />}
-          {!wideScreen && <CertificateStatus />}
-          <CourseGrade />
-          <div className={`grades my-4 p-4 rounded raised-card ${applyLockedOverlay}`} aria-hidden={gradesFeatureIsFullyLocked}>
-            <GradeSummary />
-            <DetailedGrades />
-          </div>
+          {!wideScreen && <ProgressTabCertificateStatusSlot courseId={courseId} />}
+          <ProgressTabCourseGradeSlot courseId={courseId} />
+          <ProgressTabGradeBreakdownSlot courseId={courseId} />
         </div>
 
         {/* Side panel */}
         <div className="col-12 col-md-4 p-0 px-md-4">
-          {wideScreen && <CertificateStatus />}
-          <RelatedLinks />
+          {wideScreen && <ProgressTabCertificateStatusSlot courseId={courseId} />}
+          <ProgressTabRelatedLinksSlot courseId={courseId} />
         </div>
       </div>
     </>

--- a/src/plugin-slots/ProgressTabCertificateStatusSlot/README.md
+++ b/src/plugin-slots/ProgressTabCertificateStatusSlot/README.md
@@ -1,0 +1,44 @@
+# Progress Tab Certificate Status Slot
+
+### Slot ID: `progress_tab_certificate_status_slot`
+### Props:
+* `courseId`
+
+## Description
+
+This slot is used to replace or modify the Certificate Status component in the 
+Progress Tab.
+
+## Example
+
+The following `env.config.jsx` will render the `course_id` and `unit_id` of the course as `<p>` elements in a `<div>`.
+
+![Screenshot of Content added after the Sequence Container](./images/post_sequence_container.png)
+
+```js
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+const config = {
+  pluginSlots: {
+    progress_tab_certificate_status_slot: {
+      plugins: [
+        {
+          // Insert custom content after certificate status
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_certificate_status_content',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ({courseId}) => (
+              <div>
+                <p>📚: {courseId}</p>
+              </div>
+            ),
+          },
+        },
+      ]
+    }
+  },
+}
+
+export default config;
+```

--- a/src/plugin-slots/ProgressTabCertificateStatusSlot/index.jsx
+++ b/src/plugin-slots/ProgressTabCertificateStatusSlot/index.jsx
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+import CertificateStatus from '../../course-home/progress-tab/certificate-status/CertificateStatus';
+
+const ProgressTabCertificateStatusSlot = ({ courseId }) => (
+  <PluginSlot
+    id="progress_tab_certificate_status_slot"
+    pluginProps={{
+      courseId,
+    }}
+  >
+    <CertificateStatus />
+  </PluginSlot>
+);
+
+ProgressTabCertificateStatusSlot.propTypes = {
+  courseId: PropTypes.string.isRequired,
+};
+
+export default ProgressTabCertificateStatusSlot;

--- a/src/plugin-slots/ProgressTabCourseGradeSlot/README.md
+++ b/src/plugin-slots/ProgressTabCourseGradeSlot/README.md
@@ -1,0 +1,43 @@
+# Progress Tab Course Grade Slot
+
+### Slot ID: `progress_tab_course_grade_slot`
+### Props:
+* `courseId`
+
+## Description
+
+This slot is used to replace or modify the Course Grades view in the Progress Tab.
+
+## Example
+
+The following `env.config.jsx` will render the `course_id` and `unit_id` of the course as `<p>` elements in a `<div>`.
+
+![Screenshot of Content added after the Sequence Container](./images/post_sequence_container.png)
+
+```js
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+const config = {
+  pluginSlots: {
+    progress_tab_course_grade_slot: {
+      plugins: [
+        {
+          // Insert custom content after course grade widget
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_course_grade_content',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ({courseId}) => (
+              <div>
+                <p>📚: {courseId}</p>
+              </div>
+            ),
+          },
+        },
+      ]
+    }
+  },
+}
+
+export default config;
+```

--- a/src/plugin-slots/ProgressTabCourseGradeSlot/index.jsx
+++ b/src/plugin-slots/ProgressTabCourseGradeSlot/index.jsx
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+import CourseGrade from '../../course-home/progress-tab/grades/course-grade/CourseGrade';
+
+const ProgressTabCourseGradeSlot = ({ courseId }) => (
+  <PluginSlot
+    id="progress_tab_course_grade_slot"
+    pluginProps={{
+      courseId,
+    }}
+  >
+    <CourseGrade />
+  </PluginSlot>
+);
+
+ProgressTabCourseGradeSlot.propTypes = {
+  courseId: PropTypes.string.isRequired,
+};
+
+export default ProgressTabCourseGradeSlot;

--- a/src/plugin-slots/ProgressTabGradeBreakdownSlot/README.md
+++ b/src/plugin-slots/ProgressTabGradeBreakdownSlot/README.md
@@ -1,0 +1,43 @@
+# Progress Tab Grade Summary Slot
+
+### Slot ID: `progress_tab_grade_summary_slot`
+### Props:
+* `courseId`
+
+## Description
+
+This slot is used to replace or modify the Grade Summary view in the Progress Tab.
+
+## Example
+
+The following `env.config.jsx` will render the `course_id` and `unit_id` of the course as `<p>` elements in a `<div>`.
+
+![Screenshot of Content added after the Sequence Container](./images/post_sequence_container.png)
+
+```js
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+const config = {
+  pluginSlots: {
+    progress_tab_grade_summary_slot: {
+      plugins: [
+        {
+          // Insert custom content after grade summary widget
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_grade_summary_content',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ({courseId}) => (
+              <div>
+                <p>📚: {courseId}</p>
+              </div>
+            ),
+          },
+        },
+      ]
+    }
+  },
+}
+
+export default config;
+```

--- a/src/plugin-slots/ProgressTabGradeBreakdownSlot/index.jsx
+++ b/src/plugin-slots/ProgressTabGradeBreakdownSlot/index.jsx
@@ -1,0 +1,33 @@
+import { useModel } from '@src/generic/model-store';
+import PropTypes from 'prop-types';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+import React from 'react';
+import DetailedGrades from '../../course-home/progress-tab/grades/detailed-grades/DetailedGrades';
+import GradeSummary from '../../course-home/progress-tab/grades/grade-summary/GradeSummary';
+
+const ProgressTabGradeBreakdownSlot = ({ courseId }) => {
+  const { gradesFeatureIsFullyLocked } = useModel('progress', courseId);
+  const applyLockedOverlay = gradesFeatureIsFullyLocked ? 'locked-overlay' : '';
+  return (
+    <PluginSlot
+      id="progress_tab_grade_breakdown_slot"
+      pluginProps={{
+        courseId,
+      }}
+    >
+      <div
+        className={`grades my-4 p-4 rounded raised-card ${applyLockedOverlay}`}
+        aria-hidden={gradesFeatureIsFullyLocked}
+      >
+        <GradeSummary />
+        <DetailedGrades />
+      </div>
+    </PluginSlot>
+  );
+};
+
+ProgressTabGradeBreakdownSlot.propTypes = {
+  courseId: PropTypes.string.isRequired,
+};
+
+export default ProgressTabGradeBreakdownSlot;

--- a/src/plugin-slots/ProgressTabRelatedLinksSlot/README.md
+++ b/src/plugin-slots/ProgressTabRelatedLinksSlot/README.md
@@ -1,0 +1,43 @@
+# Progress Tab Related Links Slot
+
+### Slot ID: `progress_tab_related_links_slot`
+### Props:
+* `courseId`
+
+## Description
+
+This slot is used to replace or modify the related links view in the Progress Tab.
+
+## Example
+
+The following `env.config.jsx` will render the `course_id` and `unit_id` of the course as `<p>` elements in a `<div>`.
+
+![Screenshot of Content added after the Sequence Container](./images/post_sequence_container.png)
+
+```js
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+const config = {
+  pluginSlots: {
+    progress_tab_related_links_slot: {
+      plugins: [
+        {
+          // Insert custom content after related links widget
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_related_links_content',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ({courseId}) => (
+              <div>
+                <p>📚: {courseId}</p>
+              </div>
+            ),
+          },
+        },
+      ]
+    }
+  },
+}
+
+export default config;
+```

--- a/src/plugin-slots/ProgressTabRelatedLinksSlot/index.jsx
+++ b/src/plugin-slots/ProgressTabRelatedLinksSlot/index.jsx
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+import RelatedLinks from '../../course-home/progress-tab/related-links/RelatedLinks';
+
+const ProgressTabRelatedLinksSlot = ({ courseId }) => (
+  <PluginSlot
+    id="progress_tab_related_links_slot"
+    pluginProps={{
+      courseId,
+    }}
+  >
+    <RelatedLinks />
+  </PluginSlot>
+);
+
+ProgressTabRelatedLinksSlot.propTypes = {
+  courseId: PropTypes.string.isRequired,
+};
+
+export default ProgressTabRelatedLinksSlot;


### PR DESCRIPTION
This is a Redwood backport of https://github.com/openedx/frontend-app-learning/pull/1496.

_Private-ref: [BB-9200](https://tasks.opencraft.com/browse/BB-9200)_