### PR TITLE
[BB-10930] Add missing plugin slots for syllabus tab

### DIFF
--- a/src/course-tabs/CourseTabLink.tsx
+++ b/src/course-tabs/CourseTabLink.tsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames';
+import React from 'react';
+
+interface CourseTabLinkProps {
+  slug: string;
+  activeTabSlug?: string;
+  url: string;
+  title: string;
+}
+
+export const CourseTabLink = ({
+  slug, activeTabSlug, url, title,
+}: CourseTabLinkProps) => (
+  <a
+    href={url}
+    className={classNames('nav-item flex-shrink-0 nav-link', { active: slug === activeTabSlug })}
+  >
+    {title}
+  </a>
+);

--- a/src/course-tabs/CourseTabLinksList.tsx
+++ b/src/course-tabs/CourseTabLinksList.tsx
@@ -1,0 +1,15 @@
+import { CourseTabLink } from '@src/course-tabs/CourseTabLink';
+import React from 'react';
+
+interface CourseTabLinkListProps {
+  tabs: Array<{ title: string; slug: string; url: string }>,
+  activeTabSlug?: string;
+}
+
+export const CourseTabLinksList = ({ tabs, activeTabSlug }: CourseTabLinkListProps) => (
+  <>
+    {tabs.map(({ url, title, slug }) => (
+      <CourseTabLink key={slug} url={url} slug={slug} title={title} activeTabSlug={activeTabSlug} />
+    ))}
+  </>
+);

--- a/src/course-tabs/CourseTabsNavigation.tsx
+++ b/src/course-tabs/CourseTabsNavigation.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import classNames from 'classnames';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { CoursewareSearch, CoursewareSearchToggle } from '../course-home/courseware-search';
 import { useCoursewareSearchState } from '../course-home/courseware-search/hooks';
 
+import { CourseTabLinksSlot } from '../plugin-slots/CourseTabLinksSlot';
 import Tabs from '../generic/tabs/Tabs';
 import messages from './messages';
 
@@ -32,15 +32,7 @@ const CourseTabsNavigation = ({
               className="nav-underline-tabs"
               aria-label={intl.formatMessage(messages.courseMaterial)}
             >
-              {tabs.map(({ url, title, slug }) => (
-                <a
-                  key={slug}
-                  className={classNames('nav-item flex-shrink-0 nav-link', { active: slug === activeTabSlug })}
-                  href={url}
-                >
-                  {title}
-                </a>
-              ))}
+              <CourseTabLinksSlot tabs={tabs} activeTabSlug={activeTabSlug} />
             </Tabs>
           </div>
           <div className="search-toggle">

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,7 @@ import {
   getConfig,
 } from '@edx/frontend-platform';
 import { AppProvider, ErrorPage, PageWrap } from '@edx/frontend-platform/react';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Routes, Route } from 'react-router-dom';
@@ -139,6 +140,17 @@ subscribe(APP_READY, () => {
                       element={(
                         <DecodePageRoute>
                           <CoursewareContainer />
+                        </DecodePageRoute>
+                      )}
+                    />
+                  ))}
+                  {getConfig()?.PLUGIN_ROUTES?.map((route) => (
+                    <Route
+                      key={route}
+                      path={route}
+                      element={(
+                        <DecodePageRoute>
+                          <PluginSlot id="course_page_route_slot" pluginProps={{ route }} />
                         </DecodePageRoute>
                       )}
                     />

--- a/src/plugin-slots/CourseTabLinksSlot/README.md
+++ b/src/plugin-slots/CourseTabLinksSlot/README.md
@@ -1,0 +1,51 @@
+# Course Tab Links Slot
+
+### Slot ID: `org.openedx.frontend.learning.course_tab_links.v1`
+
+### Props:
+* `activeTabSlug`: The slug of the currently active tab.
+
+## Description
+
+This slot is used to replace/modify/hide the course tabs.
+
+## Example
+
+### Added link to Course Tabs
+![Added "Custom Tab" to course tabs](./course-tabs-custom.png)
+
+The following `env.config.jsx` will add a new course tab call "Custom Tab".
+
+```js
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+import { CourseTabLink } from '@src/course-tabs/CourseTabLink';
+
+
+const config = {
+  pluginSlots: {
+    "org.openedx.frontend.learning.course_tab_links.v1": {
+      keepDefault: true,
+      plugins: [
+        {
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_tab',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ({ activeTabSlug })=> (
+              <CourseTabLink
+                url="/some/path"
+                slug="custom-link"
+                title="Custom Tab"
+                activeTabSlug={activeTabSlug}
+              />
+            ),
+          },
+        },
+      ],
+    },
+  },
+}
+
+export default config;
+```

--- a/src/plugin-slots/CourseTabLinksSlot/index.tsx
+++ b/src/plugin-slots/CourseTabLinksSlot/index.tsx
@@ -1,0 +1,21 @@
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+import { CourseTabLinksList } from '@src/course-tabs/CourseTabLinksList';
+import React from 'react';
+
+type CourseTabList = Array<{
+  title: string;
+  slug: string;
+  url: string;
+}>;
+
+export const CourseTabLinksSlot = ({ tabs, activeTabSlug }: {
+  tabs: CourseTabList,
+  activeTabSlug?: string
+}) => (
+  <PluginSlot
+    id="org.openedx.frontend.learning.course_tab_links.v1"
+    pluginProps={{ activeTabSlug }}
+  >
+    <CourseTabLinksList tabs={tabs} activeTabSlug={activeTabSlug} />
+  </PluginSlot>
+);


### PR DESCRIPTION
## Description

The [Syllabus Tab frontend plugin](https://github.com/open-craft/frontend-plugin-syllabus-tab) needs two learning-MFE plugin slots that don't exist in the Ulmo branch:

- **`org.openedx.frontend.learning.course_tab_links.v1`** - lets the plugin insert a "Syllabus" tab link. Backported from upstream `release/verawood` (added in openedx/frontend-app-learning#1645, which merged just after the Ulmo cut).
- **`course_page_route_slot`** - lets the plugin register the `/course/:courseId/syllabus` page route. Ported from the `wgu-release/redwood.1` branch.

## Supporting Information

OpenCraft Internal Jira task: [BB-10930](https://tasks.opencraft.com/browse/BB-10930)

## Testing instructions

Requires the plugin from open-craft/frontend-plugin-syllabus-tab#2 installed in a learning MFE built from this branch (wired via `env.config.jsx` exporting `pluginSlots` + `PLUGIN_ROUTES`).

1. Build/run the learning MFE from this branch with the syllabus plugin installed.
2. Open any course in the MFE.
3. **Tab-link slot:** confirm a **Syllabus** tab appears in the course tab bar.
4. **Route slot:** navigate to `…/learning/course/<courseId>/syllabus` and confirm the syllabus page renders (not a redirect to home or a 404).
5. Confirm the existing tabs (Course/Progress/Dates/etc.) still render and behave normally.